### PR TITLE
Confirmation for Asus FX705DY support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If your machine does expose keyboard backlight as USB device (you see any device
 |FX505DD (not tested)    |?           |?                   |                   |
 |FX505DY                 |FX505DY.308 |Arch Linux          |5.1.15-arch1-1-ARCH|
 |FX705GE                 |?           |?                   |?                  |
+|FX705DY                 |FX705DY.304 |openSUSE Tumbleweed |5.1.16-1-default   |
 
 See "Contributing" section for other versions.
 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -2913,6 +2913,14 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "FX705GE"),
 		},
 	},
+        {
+                .callback = dmi_check_callback,
+                .ident = "FX705DY",
+                .matches = {
+                        DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+                        DMI_MATCH(DMI_PRODUCT_NAME, "FX705DY"),
+                },
+        },	
 	{ }
 };
 


### PR DESCRIPTION
I can confirm that the keyboard LED back-light control for Asus TUF FX705DY is supported by the driver.  Dimming and re-activation after suspend mode is working. Thanks!
