### PR TITLE
Fix looped fan_mode_store calls on fan_mode sysfs file write

### DIFF
--- a/src/faustus.c
+++ b/src/faustus.c
@@ -1918,15 +1918,16 @@ static ssize_t fan_mode_show(struct device *dev,
 static ssize_t fan_mode_store(struct device *dev, struct device_attribute *attr,
 		const char *buf, size_t count)
 {
-	int result;
 	u8 new_mode;
+
+	ssize_t consumed_bytes = strlen(buf);
 
 	struct asus_wmi *asus = dev_get_drvdata(dev);
 
-	result = kstrtou8(buf, 10, &new_mode);
-	if (result < 0) {
+	int successfully_converted = kstrtou8(buf, 10, &new_mode);
+	if (successfully_converted < 0) {
 		pr_warn("Trying to store invalid value\n");
-		return result;
+		return -EINVAL;
 	}
 
 	if (new_mode == ASUS_FAN_MODE_OVERBOOST) {
@@ -1942,7 +1943,7 @@ static ssize_t fan_mode_store(struct device *dev, struct device_attribute *attr,
 	asus->fan_mode = new_mode;
 	fan_mode_write(asus);
 
-	return result;
+	return consumed_bytes;
 }
 
 // Fan mode: 0 - normal, 1 - overboost, 2 - silent


### PR DESCRIPTION
According to https://www.kernel.org/doc/Documentation/filesystems/sysfs.txt:
- store() should return the number of bytes used from the buffer. If the
  entire buffer has been used, just return the count argument.

So, it should return (ssize_t) 2 for following command:
echo "2" > /sys/devices/platform/faustus/fan_mode
(actually, echo append a '\n' to its argument, and really write '2\n' to the
sysfs file, which is 2 bytes).

Now, following tests will wokr correctly:
# Fan mode will be set to 1
echo 1 > /sys/devices/platform/faustus/fan_mode
# Fan mode will be set to 2 (no trialing '\n')
printf '2' > /sys/devices/platform/faustus/fan_mode
# Fan mode will be set to 2, then to 1, then to 0 (multi-line write)
printf '2\n1\n0\n' > /sys/devices/platform/faustus/fan_mode

And, following tests will fail gracefully with "EINVAL 22 Invalid argument":
# Fan mode will not change - invalid value
echo 22 > /sys/devices/platform/faustus/fan_mode
# Fan mode will not change - invalid value (no trialing '\n')
printf '22' > /sys/devices/platform/faustus/fan_mode
# Fan mode will be set to 2 - invalid value ('\0' byte in 2nd "mode" string)
printf '2\n\0\n' > /sys/devices/platform/faustus/fan_mode
# Fan mode will be set to 2 - invalid value ('\0' byte in 1st "mode" string)
printf '2\0\n' > /sys/devices/platform/faustus/fan_mode
# Fan mode will not change - invalid value ('\0' byte before number)
printf '\01\n' > /sys/devices/platform/faustus/fan_mode
Fixes https://github.com/hackbnw/faustus/issues/9 issue.