### PR TITLE
Works on FX505DU

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ If your machine does expose keyboard backlight as USB device (you see any device
 
 ## Systems
 
-|Model                   |BIOS        |OS                  |Kernel version     |
-|-                       |-           |-                   |-                  |
-|FX505GM                 |FX505GM.301 |Ubuntu 18.04.2 LTS  |4.18.0-25-generic  |
-|FX505DD (not tested)    |?           |?                   |                   |
-|FX505DY                 |FX505DY.308 |Arch Linux          |5.1.15-arch1-1-ARCH|
-|FX705GE                 |?           |?                   |?                  |
-|FX705DY                 |FX705DY.304 |openSUSE Tumbleweed |5.1.16-1-default   |
-|FX505GD                 |FX505GD.304 |?                   |?                  |
-|FX505DT                 |FX505DT.304 |?                   |?                  |
-|FX705DT                 |FX705DT.308 |?                   |?                  |
+|Model                   |BIOS        |OS                  |Kernel version      |
+|-                       |-           |-                   |-                   |
+|FX505GM                 |FX505GM.301 |Ubuntu 18.04.2 LTS  |4.18.0-25-generic   |
+|FX505DD (not tested)    |?           |?                   |                    |
+|FX505DY                 |FX505DY.308 |Arch Linux          |5.1.15-arch1-1-ARCH |
+|FX705GE                 |?           |?                   |?                   |
+|FX705DY                 |FX705DY.304 |openSUSE Tumbleweed |5.1.16-1-default    |
+|FX505GD                 |FX505GD.304 |?                   |?                   |
+|FX505DT                 |FX505DT.304 |?                   |?                   |
+|FX705DT                 |FX705DT.308 |?                   |?                   |
+|FX505DU                 |FX505DU.308 |Manjaro 18.1.5      |5.4.13-3-MANJARO    |
 
 See "Contributing" section for other versions.
 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -2935,14 +2935,14 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "FX705GE"),
 		},
 	},
-        {
-                .callback = dmi_check_callback,
-                .ident = "FX705DY",
-                .matches = {
-                        DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-                        DMI_MATCH(DMI_PRODUCT_NAME, "FX705DY"),
-                },
-        },
+	{
+		.callback = dmi_check_callback,
+		.ident = "FX705DY",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FX705DY"),
+		},
+	},
 	{
 		.callback = dmi_check_callback,
 		.ident = "FX505GD",
@@ -2967,7 +2967,14 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "FX705DT"),
 		},
 	},
-	{ }
+	{
+		.callback = dmi_check_callback,
+		.ident = "FX505DU",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FX505DU"),
+		},
+	}
 };
 
 static int __init atw_init(void)


### PR DESCRIPTION
### System Info

**OS:** Manjaro 18.1.5 Juhraya
**Kernel:** x86_64 Linux 5.4.13-3-MANJARO

```
$ sudo dmidecode | grep "BIOS Inf\|Board Inf" -A 3 
BIOS Information
	Vendor: American Megatrends Inc.
	Version: FX505DU.308
	Release Date: 09/19/2019
--
Base Board Information
	Manufacturer: ASUSTeK COMPUTER INC.
	Product Name: FX505DU
	Version: 1.0
```

**Attached DSDT:** [FX505DU DSDT dump.zip](https://github.com/hackbnw/faustus/files/4093257/FX505DU.DSDT.dump.zip)
