### PR TITLE
Fix compile for kernel 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If your machine does expose keyboard backlight as USB device (you see any device
 |FX505DD (not tested)    |?           |?                   |                   |
 |FX505DY                 |FX505DY.308 |Arch Linux          |5.1.15-arch1-1-ARCH|
 |FX705GE                 |?           |?                   |?                  |
+|FX705DY                 |FX705DY.304 |openSUSE Tumbleweed |5.1.16-1-default   |
 
 See "Contributing" section for other versions.
 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -2913,6 +2913,14 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "FX705GE"),
 		},
 	},
+        {
+                .callback = dmi_check_callback,
+                .ident = "FX705DY",
+                .matches = {
+                        DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+                        DMI_MATCH(DMI_PRODUCT_NAME, "FX705DY"),
+                },
+        },	
 	{ }
 };
 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -48,6 +48,7 @@
 #include <linux/acpi.h>
 #include <linux/dmi.h>
 #include <acpi/video.h>
+#include <linux/units.h>
 
 #include "faustus.h"
 
@@ -1693,7 +1694,7 @@ static ssize_t asus_hwmon_temp1(struct device *dev,
 	if (err < 0)
 		return err;
 
-	value = DECI_KELVIN_TO_CELSIUS((value & 0xFFFF)) * 1000;
+	value = deci_kelvin_to_celsius((value & 0xFFFF)) * 1000;
 
 	return sprintf(buf, "%d\n", value);
 }


### PR DESCRIPTION
The patch is only compatible with kernel version 5.6+ because units.h was not available before.
