### PR TITLE
fix compile for kernel 5.6+

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,8 +1,7 @@
 PACKAGE_VERSION="0.2"
 
 PACKAGE_NAME="faustus"
-MAKE[0]="make -C ${kernel_source_dir} SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
-CLEAN="make -C ${kernel_source_dir} SUBDIRS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"
+MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build modules"
 
 BUILT_MODULE_NAME[0]="faustus"
 BUILT_MODULE_LOCATION[0]="src/"

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -44,7 +44,6 @@
 #include <linux/debugfs.h>
 #include <linux/seq_file.h>
 #include <linux/platform_device.h>
-#include <linux/thermal.h>
 #include <linux/acpi.h>
 #include <linux/dmi.h>
 #include <acpi/video.h>

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -48,6 +48,7 @@
 #include <linux/acpi.h>
 #include <linux/dmi.h>
 #include <acpi/video.h>
+#include <linux/units.h>
 
 #include "faustus.h"
 
@@ -1695,7 +1696,7 @@ static ssize_t asus_hwmon_temp1(struct device *dev,
 	if (err < 0)
 		return err;
 
-	value = DECI_KELVIN_TO_CELSIUS((value & 0xFFFF)) * 1000;
+	value = deci_kelvin_to_celsius((value & 0xFFFF)) * 1000;
 
 	return sprintf(buf, "%d\n", value);
 }


### PR DESCRIPTION
uses units.h (which is not available before version 5.6)