### PR TITLE
Update Driver for Kernel 5.6.6 and Add Support for FX505DU

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ If your machine does expose keyboard backlight as USB device (you see any device
 
 ## Systems
 
-|Model                   |BIOS        |OS                  |Kernel version     |
-|-                       |-           |-                   |-                  |
-|FX505GM                 |FX505GM.301 |Ubuntu 18.04.2 LTS  |4.18.0-25-generic  |
-|FX505DD (not tested)    |?           |?                   |                   |
-|FX505DY                 |FX505DY.308 |Arch Linux          |5.1.15-arch1-1-ARCH|
-|FX705GE                 |?           |?                   |?                  |
-|FX705DY                 |FX705DY.304 |openSUSE Tumbleweed |5.1.16-1-default   |
-|FX505GD                 |FX505GD.304 |?                   |?                  |
-|FX505DT                 |FX505DT.304 |?                   |?                  |
-|FX705DT                 |FX705DT.308 |?                   |?                  |
-
+| Model                | BIOS        | OS                  | Kernel version      |
+|----------------------|-------------|---------------------|---------------------|
+| FX505GM              | FX505GM.301 | Ubuntu 18.04.2 LTS  | 4.18.0-25-generic   |
+| FX505DD (not tested) | ?           | ?                   |                     |
+| FX505DY              | FX505DY.308 | Arch Linux          | 5.1.15-arch1-1-ARCH |
+| FX705GE              | ?           | ?                   | ?                   |
+| FX705DY              | FX705DY.304 | openSUSE Tumbleweed | 5.1.16-1-default    |
+| FX505GD              | FX505GD.304 | ?                   | ?                   |
+| FX505DT              | FX505DT.304 | ?                   | ?                   |
+| FX705DT              | FX705DT.308 | ?                   | ?                   |
+| FX505DU              | FX505DU.310 | openSUSE Tumbleweed | 5.6.6-1-default     |
 See "Contributing" section for other versions.
 
 To check your exact model run 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -44,7 +44,7 @@
 #include <linux/debugfs.h>
 #include <linux/seq_file.h>
 #include <linux/platform_device.h>
-#include <linux/thermal.h>
+#include <linux/units.h>
 #include <linux/acpi.h>
 #include <linux/dmi.h>
 #include <acpi/video.h>
@@ -1695,7 +1695,7 @@ static ssize_t asus_hwmon_temp1(struct device *dev,
 	if (err < 0)
 		return err;
 
-	value = DECI_KELVIN_TO_CELSIUS((value & 0xFFFF)) * 1000;
+	value = deci_kelvin_to_celsius((value & 0xFFFF)) * 1000;
 
 	return sprintf(buf, "%d\n", value);
 }

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -2961,6 +2961,14 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 	},
 	{
 		.callback = dmi_check_callback,
+		.ident = "FX505DU",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FX505DU"),
+		},
+	},
+	{
+		.callback = dmi_check_callback,
 		.ident = "FX705DT",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),


### PR DESCRIPTION
What it says in the title.