### PR TITLE
add FX506LH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is a backport of the asus-wmi / asus-nb-wmi drivers from the mainline + RGB b
 |FA706II                 |FA706II.304 |?                      |?                           |1 (#62)
 |FA706IU                 |FA706IU.315 |?                      |5.11.8-051108-generic       |1, 2 (#62)
 |FX506LI                 |FX506LI.304 |Ubuntu 20.04           |5.4.0-70-generic            |1, 2 (#63)
-|FX506LH		 |FX506LH.310 |Ubuntu 22.04	      |5.15.36-xanmod1		   |2
+|FX506LH		 |FX506LH.310 |Ubuntu 22.04	      |5.15.36-xanmod1		   |1, 2
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It is a backport of the asus-wmi / asus-nb-wmi drivers from the mainline + RGB b
 |FA706II                 |FA706II.304 |?                      |?                           |1 (#62)
 |FA706IU                 |FA706IU.315 |?                      |5.11.8-051108-generic       |1, 2 (#62)
 |FX506LI                 |FX506LI.304 |Ubuntu 20.04           |5.4.0-70-generic            |1, 2 (#63)
+|FX506LH		 |FX506LH.310 |Ubuntu 22.04	      |5.15.36-xanmod1		   |2
 
 Notes:
 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -3433,10 +3433,10 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 	},
 	{
 		.callback = dmi_check_callback,
-		.ident = "FA506IH",
+		.ident = "FA506HL",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "FA506IH"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FA506HL"),
 		},
 	},
 	{}

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -3431,6 +3431,14 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "FX506LI"),
 		},
 	},
+	{
+		.callback = dmi_check_callback,
+		.ident = "FA506IH",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FA506IH"),
+		},
+	},
 	{}
 };
 

--- a/src/faustus.c
+++ b/src/faustus.c
@@ -3433,10 +3433,10 @@ static const struct dmi_system_id atw_dmi_list[] __initconst = {
 	},
 	{
 		.callback = dmi_check_callback,
-		.ident = "FA506HL",
+		.ident = "FX506LH",
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
-			DMI_MATCH(DMI_PRODUCT_NAME, "FA506HL"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FX506LH"),
 		},
 	},
 	{}


### PR DESCRIPTION
This works on

```
BIOS Information
	Vendor: American Megatrends Inc.
	Version: FX506LH.310
	Release Date: 11/26/2021
--
Base Board Information
	Manufacturer: ASUSTeK COMPUTER INC.
	Product Name: FX506LH
	Version: 1.0
```

~~Fan mode by fn+f5 is supported.~~
**EDITED**:
After press fn + f5 changed thermal policy but not fan boost mode.

RGB hot keys (Fn-Left, Fn-Right) are not functional.